### PR TITLE
fix memcached wrapper

### DIFF
--- a/lib/cachy.rb
+++ b/lib/cachy.rb
@@ -159,10 +159,10 @@ module Cachy
     elsif cache.class.to_s == 'Redis'
       require 'cachy/redis_wrapper'
       RedisWrapper.new(cache)
-    elsif cache.respond_to? "[]" and cache.respond_to? :set
+    elsif cache.respond_to? :get and cache.respond_to? :set
       require 'cachy/memcached_wrapper'
       MemcachedWrapper.new(cache)
-    elsif cache.respond_to? "[]" and cache.respond_to? :store
+    elsif cache.respond_to? :[] and cache.respond_to? :store
       require 'cachy/moneta_wrapper'
       MonetaWrapper.new(cache)
     else

--- a/lib/cachy/memcached_wrapper.rb
+++ b/lib/cachy/memcached_wrapper.rb
@@ -1,6 +1,10 @@
 require 'cachy/wrapper'
 
 class Cachy::MemcachedWrapper < Cachy::Wrapper
+  def read(key)
+    @wrapped.get(key)
+  end
+
   def write(key, result, options={})
     @wrapped.set(key, result, options[:expires_in].to_i)
   end

--- a/spec/mem_cache.rb
+++ b/spec/mem_cache.rb
@@ -21,10 +21,6 @@ class MemCache
     @wrapped[key]
   end
 
-  def [](x)
-    @wrapped[x]
-  end
-
   def clear
     @wrapped.clear
   end


### PR DESCRIPTION
Cachy is looking for the `[]` method in a memcached cache_store, which neither the memcached gem, nor dalli has. Instead, as cachy's readme correctly states, they use the `get` method. In this change, I pointed Cachy at the correct method.
