### PR TITLE
Fixed redis wrapper spec incorrect yaml line endings

### DIFF
--- a/spec/cachy/redis_wrapper_spec.rb
+++ b/spec/cachy/redis_wrapper_spec.rb
@@ -30,7 +30,7 @@ class TestRedis
 end
 
 describe "Cachy::RedisWrapper" do
-  let(:yaml_ending) { RUBY_VERSION > '1.9' ? "\n...\n" : "\n" }
+  let(:yaml_ending) { RUBY_VERSION > '1.9.2' ? "\n...\n" : "\n" }
 
   before :all do
     @cache = TestRedis.new


### PR DESCRIPTION
The redis wrapper spec made the incorrect assumption that the default yaml line endings have been changed at ruby 1.9. This is incorrect, the default yamler was Syck up until 1.9.2, and Psych from then on, this is what causes the line endings to differ across versions.
